### PR TITLE
Find documents by matching _id for PUT stock

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -117,17 +117,16 @@ exports.stock = functions.https.onRequest(async (req, res) => {
         let _id = fooditem.replace(/\s+/g, '');
 
         //check for uniqueness
-        let query = docRef.where("_id", "==", _id);
+        let query = docRef.doc(_id);
         let checkDoc = await query.get();
         if (!checkDoc.exists) {
             let timestamp = new Timestamp(Math.floor(new Date() / 1000), 0)
             let json = {
-                "_id": _id,
                 "name": fooditem,
                 "count": data.count,
                 "timestamp": timestamp
             }
-            docRef.add(json).then(() => {
+            docRef.doc(_id).set(json).then(() => {
                 return res.sendStatus(200);
             })
                 .catch(error => {
@@ -151,6 +150,8 @@ exports.stock = functions.https.onRequest(async (req, res) => {
         let pantry = data.pantry;
         let _id = data._id;
         let newCount = data.newCount;
+        
+        console.log(newCount)
 
         if (pantry === undefined) {
             res.status(422).send("Problem with pantry name");

--- a/functions/index.js
+++ b/functions/index.js
@@ -89,10 +89,11 @@ exports.stock = functions.https.onRequest(async (req, res) => {
         let docRef = admin.firestore().collection("pantries").doc(pantry).collection("stock");
         docRef.get().then(qSnapshot => {
             let r = []
-            console.log("inside docref");
             qSnapshot.forEach(doc => {
-                console.log(doc.data());
-                r.push(doc.data())
+                let data = doc.data();
+                data._id= doc.id;
+                console.log(data)
+                r.push(data)
             });
             return res.status(200).jsonp(r);
         })
@@ -156,22 +157,10 @@ exports.stock = functions.https.onRequest(async (req, res) => {
         if (pantry === undefined) {
             res.status(422).send("Problem with pantry name.");
         } else {
-            const pantryStock = admin.firestore().collection("pantries").doc(pantry).collection("stock");
-            
-            // Fetch snapshot of documents with matching _id
-            const snapshot = await pantryStock.where('_id', '==', _id).get();
-            
-            // If no documents are found, return error response.
-            if (snapshot.empty) {
-                res.status(404).send('Stock item not found.')
-            } else {
-                // Update the first matching document
-                // FIXME: handle documents with identical `_id`s?
-                let docRef = snapshot.docs[0].ref;
-                docRef.update({ count: newCount })
-                docRef.update({ timestamp: new Timestamp(Math.floor(new Date() / 1000), 0) })
-                res.status(200).send("updated successfully");
-            }
+            let docRef = admin.firestore().collection("pantries").doc(pantry).collection("stock").doc(_id);
+            docRef.update({ count: newCount })
+            docRef.update({ timestamp: new Timestamp(Math.floor(new Date() / 1000), 0) })
+            res.status(204).send("updated successfully");
             
         }
 


### PR DESCRIPTION
I believe I was able to fix this, tested on emulator and seemed to work.
- Using code 404 for documents not found so frontend knows an error occurred (using 204 makes frontend think everything went fine). Not sure if it's the best code though
- Not sure what to do about stock items with identical `_id`s. I think we might need to change the schema for PUT requests to use a stock item's UID auto-generated by Firestore, which means the frontend would have to receive that as well. Thoughts @QwertycowMoo?